### PR TITLE
close

### DIFF
--- a/terraform/proxmox/modules/proxmox-lxc/main.tf
+++ b/terraform/proxmox/modules/proxmox-lxc/main.tf
@@ -32,4 +32,14 @@ resource "proxmox_lxc" "this" {
     ip     = var.network_ip
     gw     = var.network_gw
   }
+
+  // ostemplate と ssh_public_keys は作成時のみ有効かつ API から読み戻されない
+  // ForceNew 属性のため、import 済みリソースでは state 上 null となり毎回 replace を
+  // 誘発する。差分を無視して既存コンテナの再作成を防ぐ。
+  lifecycle {
+    ignore_changes = [
+      ostemplate,
+      ssh_public_keys,
+    ]
+  }
 }


### PR DESCRIPTION
## 概要

LXC(`secret_manager` / `monitoring` / `dns`)が `terraform plan` のたびに replace(再作成)を要求される問題を修正します。

## 原因

`proxmox-lxc` モジュールが設定する `ostemplate` と `ssh_public_keys` は、Telmate/proxmox プロバイダ(`3.0.1-rc6`)上で以下の性質を持ちます。

- **`ForceNew: true`**: 値が変わると in-place update ではなく replace になる
- **作成専用で API から読み戻されない**: Read 関数で state に書き戻されない("Only applicable on create and not readable")

`import.tf` のとおりこれらのコンテナは import 済みで、import 後は上記属性が state 上 `null` のまま残ります。そのため plan 毎に `null(state) → 値(config)` の差分が ForceNew 属性に発生し、replace が強制されていました。

## 変更内容

- `terraform/proxmox/modules/proxmox-lxc/main.tf` の `proxmox_lxc` リソースに `lifecycle.ignore_changes`(`ostemplate`, `ssh_public_keys`)を追加

## 検証手順

```
cd terraform/proxmox && terraform plan
```

期待結果: `module.secret_manager` / `module.monitoring` / `module.dns` の `proxmox_lxc.this` が `must be replaced` にならないこと。

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Ep7wLi4yHewsBbw4otwFr

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ep7wLi4yHewsBbw4otwFr)_