### PR TITLE
feat(ansible): Flux CDのブートストラップをsite_flux.ymlで自動化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+GITHUB_USER=""
+GITHUB_TOKEN=""
 TF_VAR_pm_api_url="https://192.168.0.200:8006"
 TF_VAR_pm_tls_insecure="true"
 TF_VAR_pm_api_token_id="terraform-prov@pve!terraform-token"
@@ -7,8 +9,3 @@ TF_VAR_pm_rootpassword=""
 TF_VAR_cipassword=""
 TF_VAR_openmediavault_passthrough_file=""
 TF_VAR_sshkeys=""
-
-# Flux CD ブートストラップ (ansible/site_flux.yml) 用の GitHub 認証情報
-# PAT は Contents 読み取り権限があれば十分
-GITHUB_USER=""
-GITHUB_TOKEN=""

--- a/.env.sample
+++ b/.env.sample
@@ -7,3 +7,8 @@ TF_VAR_pm_rootpassword=""
 TF_VAR_cipassword=""
 TF_VAR_openmediavault_passthrough_file=""
 TF_VAR_sshkeys=""
+
+# Flux CD ブートストラップ (ansible/site_flux.yml) 用の GitHub 認証情報
+# PAT は Contents 読み取り権限があれば十分
+GITHUB_USER=""
+GITHUB_TOKEN=""

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -14,6 +14,24 @@ $ ansible-galaxy install -r requirements.yml
 $ ansible-playbook site.yml
 ```
 
+## Flux CD のブートストラップ
+
+K3s クラスター構築後、`site_flux.yml` で Flux CD をブートストラップする（コントローラの適用・Git 認証シークレット作成・reconcile）。GitHub の認証情報が必要なため `site.yml` からは分離しており、明示的に実行する。
+
+前提:
+
+- コントロールノードに `kubectl` / `flux` CLI がインストール済み（Nix devshell に同梱）
+- Personal access token が発行済み（リポジトリの Contents 読み取り権限）
+
+```bash
+export GITHUB_USER=<owner>
+export GITHUB_TOKEN=<token>
+
+ansible-playbook site_flux.yml
+```
+
+`GITHUB_USER` / `GITHUB_TOKEN` は `.env` + direnv で読み込む運用を想定している（`.env.sample` 参照）。prod / staging 両クラスターを対象に、各クラスターの kubeconfig を取得してブートストラップする。
+
 ## トラブルシューティング
 
 ### k3s.orchestration.airgapロールでエラーが発生する

--- a/ansible/group_vars/k3s_prod_cluster.yml
+++ b/ansible/group_vars/k3s_prod_cluster.yml
@@ -2,3 +2,5 @@
 # token: "changeme!"
 api_endpoint: "{{ hostvars[groups['k3s_prod_cluster_server'][0]]['ansible_host'] | default(groups['k3s_prod_cluster_server'][0]) }}"
 server_group: "k3s_prod_cluster_server"
+# site_flux.yml が参照する Flux クラスターディレクトリ (kubernetes/clusters/<name>)
+flux_cluster: "production"

--- a/ansible/group_vars/k3s_stg_cluster.yml
+++ b/ansible/group_vars/k3s_stg_cluster.yml
@@ -2,3 +2,5 @@
 # token: "changeme!"
 api_endpoint: "{{ hostvars[groups['k3s_stg_cluster_server'][0]]['ansible_host'] | default(groups['k3s_stg_cluster_server'][0]) }}"
 server_group: "k3s_stg_cluster_server"
+# site_flux.yml が参照する Flux クラスターディレクトリ (kubernetes/clusters/<name>)
+flux_cluster: "staging"

--- a/ansible/site_flux.yml
+++ b/ansible/site_flux.yml
@@ -1,0 +1,83 @@
+---
+# Flux CD のブートストラップを自動化する。
+# gotk-components / gotk-sync は kubernetes/ 配下に既にコミット済みなので、
+# ここでは「コントローラの適用 → Git 認証シークレット作成 → reconcile」だけを行う。
+# kubectl / flux はコントロールノード（Nix devshell）で実行する（delegate_to: localhost）。
+#
+# 事前準備:
+#   export GITHUB_USER=<owner>
+#   export GITHUB_TOKEN=<PAT>   # Contents 読み取り権限
+#   ansible-playbook site_flux.yml
+- name: Bootstrap Flux CD
+  hosts: k3s_cluster_server
+  gather_facts: false
+  vars:
+    repo_root: "{{ playbook_dir }}/.."
+    flux_github_user: "{{ lookup('ansible.builtin.env', 'GITHUB_USER') }}"
+    flux_github_token: "{{ lookup('ansible.builtin.env', 'GITHUB_TOKEN') }}"
+    flux_kubeconfig: "{{ repo_root }}/.kube/{{ flux_cluster }}.yaml"
+    flux_system_path: "{{ repo_root }}/kubernetes/clusters/{{ flux_cluster }}/flux-system"
+
+  tasks:
+    - name: Ensure GitHub credentials are provided via environment
+      ansible.builtin.assert:
+        that:
+          - flux_github_user | length > 0
+          - flux_github_token | length > 0
+        fail_msg: >-
+          GITHUB_USER と GITHUB_TOKEN を環境変数で設定してください（例: direnv / .env）。
+        quiet: true
+
+    - name: Read kubeconfig from the K3s server
+      ansible.builtin.slurp:
+        src: /etc/rancher/k3s/k3s.yaml
+      register: flux_k3s_kubeconfig
+
+    - name: Ensure local kubeconfig directory exists
+      ansible.builtin.file:
+        path: "{{ repo_root }}/.kube"
+        state: directory
+        mode: "0700"
+      delegate_to: localhost
+
+    - name: Write kubeconfig to control node with node address
+      ansible.builtin.copy:
+        content: >-
+          {{ flux_k3s_kubeconfig.content | b64decode
+             | replace('https://127.0.0.1:6443', 'https://' ~ inventory_hostname ~ ':6443') }}
+        dest: "{{ flux_kubeconfig }}"
+        mode: "0600"
+      delegate_to: localhost
+
+    - name: Install Flux controllers (kubectl apply -k)
+      ansible.builtin.command:
+        cmd: >-
+          kubectl --kubeconfig {{ flux_kubeconfig | quote }}
+          apply -k {{ flux_system_path | quote }}
+      register: flux_apply
+      changed_when: "'created' in flux_apply.stdout or 'configured' in flux_apply.stdout"
+      delegate_to: localhost
+
+    - name: Create flux-system Git credentials secret
+      ansible.builtin.shell:
+        cmd: >-
+          set -o pipefail
+          && kubectl --kubeconfig {{ flux_kubeconfig | quote }} create secret generic flux-system
+          --namespace flux-system
+          --from-literal=username={{ flux_github_user | quote }}
+          --from-literal=password={{ flux_github_token | quote }}
+          --dry-run=client -o yaml
+          | kubectl --kubeconfig {{ flux_kubeconfig | quote }} apply -f -
+        executable: /bin/bash
+      register: flux_secret
+      changed_when: "'created' in flux_secret.stdout or 'configured' in flux_secret.stdout"
+      no_log: true
+      delegate_to: localhost
+
+    - name: Reconcile flux-system Git source
+      ansible.builtin.command:
+        cmd: >-
+          flux --kubeconfig {{ flux_kubeconfig | quote }}
+          reconcile source git flux-system
+      changed_when: true
+      delegate_to: localhost

--- a/ansible/site_flux.yml
+++ b/ansible/site_flux.yml
@@ -49,13 +49,36 @@
         mode: "0600"
       delegate_to: localhost
 
-    - name: Install Flux controllers (kubectl apply -k)
+    # gotk-components(CRD+コントローラ) と gotk-sync(GitRepository/Kustomization
+    # インスタンス) を一括 apply すると、CRD 登録前にインスタンス適用が走り
+    # "no matches for kind ... ensure CRDs are installed first" で失敗する。
+    # CRD → 待機 → インスタンス の順で適用する。
+    - name: Install Flux controllers and CRDs (gotk-components)
       ansible.builtin.command:
         cmd: >-
           kubectl --kubeconfig {{ flux_kubeconfig | quote }}
-          apply -k {{ flux_system_path | quote }}
-      register: flux_apply
-      changed_when: "'created' in flux_apply.stdout or 'configured' in flux_apply.stdout"
+          apply -f {{ (flux_system_path ~ '/gotk-components.yaml') | quote }}
+      register: flux_components
+      changed_when: "'created' in flux_components.stdout or 'configured' in flux_components.stdout"
+      delegate_to: localhost
+
+    - name: Wait for Flux CRDs to be established
+      ansible.builtin.command:
+        cmd: >-
+          kubectl --kubeconfig {{ flux_kubeconfig | quote }}
+          wait --for=condition=established --timeout=60s
+          crd/gitrepositories.source.toolkit.fluxcd.io
+          crd/kustomizations.kustomize.toolkit.fluxcd.io
+      changed_when: false
+      delegate_to: localhost
+
+    - name: Apply Flux sync manifests (gotk-sync)
+      ansible.builtin.command:
+        cmd: >-
+          kubectl --kubeconfig {{ flux_kubeconfig | quote }}
+          apply -f {{ (flux_system_path ~ '/gotk-sync.yaml') | quote }}
+      register: flux_sync
+      changed_when: "'created' in flux_sync.stdout or 'configured' in flux_sync.stdout"
       delegate_to: localhost
 
     - name: Create flux-system Git credentials secret

--- a/ansible/site_flux.yml
+++ b/ansible/site_flux.yml
@@ -1,13 +1,5 @@
 ---
-# Flux CD のブートストラップを自動化する。
-# gotk-components / gotk-sync は kubernetes/ 配下に既にコミット済みなので、
-# ここでは「コントローラの適用 → Git 認証シークレット作成 → reconcile」だけを行う。
-# kubectl / flux はコントロールノード（Nix devshell）で実行する（delegate_to: localhost）。
-#
-# 事前準備:
-#   export GITHUB_USER=<owner>
-#   export GITHUB_TOKEN=<PAT>   # Contents 読み取り権限
-#   ansible-playbook site_flux.yml
+# kubectl / flux はコントロールノードで実行する（delegate_to: localhost）。使い方は README を参照。
 - name: Bootstrap Flux CD
   hosts: k3s_cluster_server
   gather_facts: false
@@ -49,10 +41,8 @@
         mode: "0600"
       delegate_to: localhost
 
-    # gotk-components(CRD+コントローラ) と gotk-sync(GitRepository/Kustomization
-    # インスタンス) を一括 apply すると、CRD 登録前にインスタンス適用が走り
-    # "no matches for kind ... ensure CRDs are installed first" で失敗する。
-    # CRD → 待機 → インスタンス の順で適用する。
+    # CRD 登録前にインスタンス適用が走ると失敗するため、components を一括 apply せず
+    # CRD → 待機 → インスタンス(sync) の順に分割する
     - name: Install Flux controllers and CRDs (gotk-components)
       ansible.builtin.command:
         cmd: >-

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -2,6 +2,19 @@
 
 ## Flux CD
 
+### Ansible で自動ブートストラップ（推奨）
+
+以下の手動手順は `ansible/site_flux.yml` で自動化済み。詳細は `ansible/README.md` を参照。
+
+```bash
+export GITHUB_USER=<owner>
+export GITHUB_TOKEN=<token>
+
+ansible-playbook site_flux.yml
+```
+
+### 手動での手順
+
 初回は`flux bootstrap`コマンドを実行する。
 
 - Flux CLIコマンドがインストール済み
@@ -29,7 +42,7 @@ flux bootstrap github \
 ```bash
 kubectl apply -k ./kubernetes/clusters/production/flux-system
 
-# ここを改善したい
+# site_flux.yml で自動化済み
 kubectl create secret generic flux-system \
   --namespace=flux-system \
   --from-literal=username="$GITHUB_USER" \


### PR DESCRIPTION
## 概要

K3sクラスター構築後に手動で実施していた **Flux CD のブートストラップ**（`kubernetes/README.md` の手順）を Ansible で自動化しました。これにより K3s 構築からアプリのデプロイまでを Ansible で完結できます。

Flux CD の GitOps 構成（`kubernetes/` 配下の MetalLB / homepage / metrics / logging / nginx）はすでに整備済みで、本 PR は未自動化だった**ブートストラップ手順のみ**を対象にしています。

## 変更内容

- **`ansible/site_flux.yml` を追加**
  - `k3s_cluster_server`（production `.110` / staging `.120`）を対象に、クラスターごとにブートストラップ
  - 処理はコントロールノード（Nix devshell の `kubectl` / `flux`）で実行（`delegate_to: localhost`）
  - フロー: GitHub 認証情報の存在チェック → 各サーバーの kubeconfig 取得＆ server URL をノードアドレスへ書き換え → `kubectl apply -k .../flux-system` でコントローラ適用 → `flux-system` シークレットを冪等作成 → `flux reconcile`
- **`group_vars/k3s_{prod,stg}_cluster.yml`** に `flux_cluster`（`production` / `staging`）を追加し、参照するクラスターディレクトリを判別
- **`.env.sample`** に `GITHUB_USER` / `GITHUB_TOKEN`（direnv 読み込み想定）を追記
- **`ansible/README.md` / `kubernetes/README.md`** に実行手順を反映

## 設計メモ

- `flux bootstrap` ではなく **`kubectl apply` 方式**を採用。`gotk-components` / `gotk-sync` は Git にコミット済みのため冪等に適用でき、リポジトリを書き換えません（`kubernetes/README.md` の「改善したい」箇所に対応）。
- GitHub PAT は環境変数 / direnv から読み込み、リポジトリに秘匿情報を残しません。シークレット作成タスクは `no_log: true`。
- `site.yml` には統合せず**独立 playbook** としています（PAT 無しでも `site.yml` の K3s 構築は動作）。

## 検証

- 追加・編集した YAML の妥当性を確認済み（実行環境に Ansible CLI が無いため `--syntax-check` / `ansible-lint` は未実行）。
- 実クラスターへの適用検証は未実施。devshell で以下を想定:
  - `ansible-playbook site_flux.yml --syntax-check` / `ansible-lint site_flux.yml`
  - 本実行後に `flux get kustomizations` で flux-system → infrastructure(metallb) → apps が Ready になること、各アプリの Pod 起動を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf57MKHwmPkYKCnZaCTio8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lf57MKHwmPkYKCnZaCTio8)_