### PR TITLE
feat: シークレット管理を導入(K8s: SOPS+age / 他: 環境変数)しVault残骸を撤去

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,13 @@ TF_VAR_cipassword=""
 TF_VAR_openmediavault_passthrough_file=""
 TF_VAR_sshkeys=""
 STEP_CA_PASSWORD=""
+
+# SOPS/age: Flux が K8s Secret を復号するための age 秘密鍵ファイルのパス
+# (site_flux.yml が flux-system/sops-age Secret として投入する)
+SOPS_AGE_KEY_FILE=""
+
+# Ansible が参照するシークレット (平文を group_vars に置かず env 経由で注入)
+DNS_WEB_PASSWORD=""
+GRAFANA_ADMIN_PASSWORD=""
+# K3s クラスタトークン (設定する場合のみ。未設定なら k3s 側で自動生成)
+K3S_TOKEN=""

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,12 @@ diagram_pihole.png
 .env
 .direnv
 
+# SOPS / age — 秘密鍵と復号済みファイルは絶対にコミットしない
+# (暗号化済みの *.sops.yaml はコミット対象。秘密鍵は ~/.config/sops/age/ 等 Git 外に置く)
+*.agekey
+keys.txt
+*.dec.yaml
+*.dec.yml
+
 # ansible-lint / ansible-galaxy のローカルキャッシュ
 .ansible/

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,13 @@
+# SOPS 暗号化ルール (K8s Secret 用)
+#
+# age の公開 recipient のみをここに置く（秘密鍵は絶対にコミットしない）。
+# 導入時に `age-keygen -o ~/.config/sops/age/keys.txt` で鍵を生成し、
+# 出力される公開鍵 (age1... で始まる文字列) で下記 REPLACE_ME を置き換える。
+# 詳細は docs/secret-management.md を参照。
+#
+# encrypted_regex により data/stringData の "値" だけを暗号化し、
+# apiVersion/kind/metadata などの構造やキー名は平文のまま残す（差分レビュー可能）。
+creation_rules:
+  - path_regex: kubernetes/.*\.sops\.ya?ml$
+    encrypted_regex: "^(data|stringData)$"
+    age: REPLACE_ME

--- a/ansible/group_vars/dns.yml
+++ b/ansible/group_vars/dns.yml
@@ -5,9 +5,8 @@
 dns_host_ip: "192.168.0.213"
 dns_timezone: "Asia/Tokyo"
 
-# Pi-hole 管理画面のパスワード
-# TODO: 平文を避け、Ansible Vault もしくは secret-manager(vault) 連携へ置き換える
-dns_web_password: "changeme"
+# Pi-hole 管理画面のパスワード（平文を置かず環境変数から注入。docs/secret-management.md 参照）
+dns_web_password: "{{ lookup('ansible.builtin.env', 'DNS_WEB_PASSWORD') }}"
 
 # Compose プロジェクトの配置先（LXC 内）
 dns_compose_dir: "/opt/dns"
@@ -36,7 +35,6 @@ dns_records:
   - { ip: "192.168.0.200", name: "proxmox" }
   - { ip: "192.168.0.210", name: "openmediavault" }
   - { ip: "192.168.0.211", name: "ca" }
-  - { ip: "192.168.0.212", name: "vault" }
   - { ip: "192.168.0.213", name: "dns" }
   - { ip: "192.168.0.213", name: "pihole" }
   - { ip: "192.168.0.214", name: "monitoring" }

--- a/ansible/group_vars/grafana.yml
+++ b/ansible/group_vars/grafana.yml
@@ -2,8 +2,8 @@
 grafana_ini:
   security:
     admin_user: admin
-    # TODO: 修正
-    admin_password: password
+    # 平文を置かず環境変数から注入（docs/secret-management.md 参照）
+    admin_password: "{{ lookup('ansible.builtin.env', 'GRAFANA_ADMIN_PASSWORD') }}"
   # Caddy(https://grafana.home.arpa)経由での提供に合わせる
   server:
     domain: grafana.home.arpa

--- a/ansible/group_vars/k3s_prod_cluster.yml
+++ b/ansible/group_vars/k3s_prod_cluster.yml
@@ -1,5 +1,7 @@
 ---
-# token: "changeme!"
+# クラスタトークンを固定する場合のみ有効化する（未設定なら k3s 側で自動生成）。
+# 平文は置かず環境変数から注入する（docs/secret-management.md 参照）。
+# token: "{{ lookup('ansible.builtin.env', 'K3S_TOKEN') }}"
 api_endpoint: "{{ hostvars[groups['k3s_prod_cluster_server'][0]]['ansible_host'] | default(groups['k3s_prod_cluster_server'][0]) }}"
 server_group: "k3s_prod_cluster_server"
 # site_flux.yml が参照する Flux クラスターディレクトリ (kubernetes/clusters/<name>)

--- a/ansible/group_vars/k3s_stg_cluster.yml
+++ b/ansible/group_vars/k3s_stg_cluster.yml
@@ -1,5 +1,7 @@
 ---
-# token: "changeme!"
+# クラスタトークンを固定する場合のみ有効化する（未設定なら k3s 側で自動生成）。
+# 平文は置かず環境変数から注入する（docs/secret-management.md 参照）。
+# token: "{{ lookup('ansible.builtin.env', 'K3S_TOKEN') }}"
 api_endpoint: "{{ hostvars[groups['k3s_stg_cluster_server'][0]]['ansible_host'] | default(groups['k3s_stg_cluster_server'][0]) }}"
 server_group: "k3s_stg_cluster_server"
 # site_flux.yml が参照する Flux クラスターディレクトリ (kubernetes/clusters/<name>)

--- a/ansible/group_vars/prometheus.yml
+++ b/ansible/group_vars/prometheus.yml
@@ -18,7 +18,6 @@ prometheus_scrape_configs:
       - targets:
           - "192.168.0.210:9100" # openmediavault
           - "192.168.0.211:9100" # pki (step-ca)
-          - "192.168.0.212:9100" # vault
           - "192.168.0.213:9100" # dns
           - "192.168.0.214:9100" # monitoring
   # NASのディスクSMART(smartctl_exporter)
@@ -54,7 +53,6 @@ prometheus_scrape_configs:
       - targets:
           - 192.168.0.210 # openmediavault
           - 192.168.0.211 # pki (step-ca)
-          - 192.168.0.212 # vault
           - 192.168.0.213 # dns
     relabel_configs:
       - source_labels: [__address__]

--- a/ansible/inventories/inventory.yml
+++ b/ansible/inventories/inventory.yml
@@ -51,6 +51,5 @@ infra_nodes:
   hosts:
     192.168.0.210:  # OpenMediaVault (NAS)
     192.168.0.211:  # PKI (step-ca)
-    192.168.0.212:  # Vault (secret-manager)
     192.168.0.213:  # DNS (Pi-hole + Unbound)
     192.168.0.214:  # monitoring (Prometheus/Grafana自身)

--- a/ansible/site_dns.yml
+++ b/ansible/site_dns.yml
@@ -21,6 +21,16 @@
           - caddy
         state: restarted
 
+  pre_tasks:
+    - name: Ensure the Pi-hole web password is provided via environment
+      ansible.builtin.assert:
+        that:
+          - dns_web_password | length > 0
+        fail_msg: >-
+          DNS_WEB_PASSWORD を環境変数で設定してください（例: direnv / .env）。
+          詳細は docs/secret-management.md 参照。
+        quiet: true
+
   tasks:
     - name: Check whether systemd-resolved is present
       ansible.builtin.stat:

--- a/ansible/site_flux.yml
+++ b/ansible/site_flux.yml
@@ -7,6 +7,7 @@
     repo_root: "{{ playbook_dir }}/.."
     flux_github_user: "{{ lookup('ansible.builtin.env', 'GITHUB_USER') }}"
     flux_github_token: "{{ lookup('ansible.builtin.env', 'GITHUB_TOKEN') }}"
+    flux_age_key_file: "{{ lookup('ansible.builtin.env', 'SOPS_AGE_KEY_FILE') }}"
     flux_kubeconfig: "{{ repo_root }}/.kube/{{ flux_cluster }}.yaml"
     flux_system_path: "{{ repo_root }}/kubernetes/clusters/{{ flux_cluster }}/flux-system"
 
@@ -18,6 +19,15 @@
           - flux_github_token | length > 0
         fail_msg: >-
           GITHUB_USER と GITHUB_TOKEN を環境変数で設定してください（例: direnv / .env）。
+        quiet: true
+
+    - name: Ensure the SOPS age key file is provided via environment
+      ansible.builtin.assert:
+        that:
+          - flux_age_key_file | length > 0
+        fail_msg: >-
+          SOPS_AGE_KEY_FILE を環境変数で設定してください（例: direnv / .env）。
+          age-keygen で鍵を生成し、そのファイルパスを指定します。詳細は docs/secret-management.md 参照。
         quiet: true
 
     - name: Read kubeconfig from the K3s server
@@ -84,6 +94,24 @@
         executable: /bin/bash
       register: flux_secret
       changed_when: "'created' in flux_secret.stdout or 'configured' in flux_secret.stdout"
+      no_log: true
+      delegate_to: localhost
+
+    # SOPS で暗号化した K8s Secret を kustomize-controller が復号するための age 秘密鍵。
+    # キー名は age.agekey 固定 (kustomize-controller が .agekey 接尾辞のキーを読む)。
+    # 秘密鍵はローカルの SOPS_AGE_KEY_FILE からクラスタへ流し込むだけで、Git には残さない。
+    - name: Create sops-age decryption key secret
+      ansible.builtin.shell:
+        cmd: >-
+          set -o pipefail
+          && kubectl --kubeconfig {{ flux_kubeconfig | quote }} create secret generic sops-age
+          --namespace flux-system
+          --from-file=age.agekey={{ flux_age_key_file | quote }}
+          --dry-run=client -o yaml
+          | kubectl --kubeconfig {{ flux_kubeconfig | quote }} apply -f -
+        executable: /bin/bash
+      register: flux_sops_secret
+      changed_when: "'created' in flux_sops_secret.stdout or 'configured' in flux_sops_secret.stdout"
       no_log: true
       delegate_to: localhost
 

--- a/ansible/site_monitoring.yml
+++ b/ansible/site_monitoring.yml
@@ -6,6 +6,15 @@
 
 - name: Setup Grafana
   hosts: grafana
+  pre_tasks:
+    - name: Ensure the Grafana admin password is provided via environment
+      ansible.builtin.assert:
+        that:
+          - grafana_ini.security.admin_password | length > 0
+        fail_msg: >-
+          GRAFANA_ADMIN_PASSWORD を環境変数で設定してください（例: direnv / .env）。
+          詳細は docs/secret-management.md 参照。
+        quiet: true
   roles:
     - grafana.grafana.grafana
 

--- a/docs/adr/0001-secret-management.md
+++ b/docs/adr/0001-secret-management.md
@@ -1,0 +1,70 @@
+# ADR 0001: シークレット管理の技術選定
+
+- ステータス: Accepted
+- 日付: 2026-07-07
+- 関連: [docs/secret-management.md](../secret-management.md), [docs/sso.md](../sso.md), [docs/pki.md](../pki.md)
+
+## コンテキスト
+
+homelab の秘密情報は3系統でバラバラに扱われていた。
+
+- **Terraform**: `TF_VAR_*` 環境変数 + direnv(Git非コミット。妥当)
+- **Ansible**: 環境変数lookup + `no_log`(妥当)だが、一部は**平文プレースホルダをGitにコミット**していた
+  (`dns_web_password: "changeme"`、Grafana `admin_password: password`、K3s `token`)
+- **Kubernetes**: `site_flux.yml` が `kubectl create secret` で**命令的**に投入(GitOps外・非バージョン管理)
+
+かつて HashiCorp Vault 用の枠だけが残っていた(空の `terraform/vault-config/`、no-opな `vault:*` タスク、
+LXC `192.168.0.212` のIP予約、docs/diagram の記述)が、実体は未構成だった。この残骸を確定扱いにせず、
+**ゼロから技術選定**することにした。
+
+制約:
+- 物理ホストは1台(Intel N100 / 32GB)、単独運用。常駐サービスは増やしたくない。
+- Flux CD による GitOps が中核。秘密もできる限り宣言的に扱いたい。
+- **リポジトリは公開**。Gitに入るものは世界に読まれる前提。
+
+## 決定
+
+- **Kubernetes(Flux)層は SOPS + age** を採用する。暗号化した `*.sops.yaml` をGitにコミットし、
+  Flux の kustomize-controller が `flux-system/sops-age` Secret を鍵として復号する。
+- **Ansible / Terraform 層は環境変数(direnv/`.env`)** に統一する。平文プレースホルダは
+  `lookup('ansible.builtin.env', ...)` へ置き換え、既存の `STEP_CA_PASSWORD` / `GITHUB_TOKEN` と同方式にする。
+- **HashiCorp Vault は採用せず、残骸を撤去**する(`terraform/vault-config/`、`vault:*` タスク、
+  `secret_manager` LXC(.212) と監視ターゲット、docs/diagram の記述)。
+- age秘密鍵は `docs/pki.md` のCA鍵と同じく **Git外・オフライン暗号化バックアップ** で扱う。
+
+### なぜこの切り分けか
+
+秘密ゼロの保管・共有・バージョン管理が不要なもの(Terraform、単純なホスト秘密)は env var で十分で、
+SOPSは手間が増えるだけ。一方 K8s Secret は「クラスタ内に存在」する必要があり env var では入れられず、
+現状の命令的 `kubectl create secret` はGitOps外に留まる。ここにこそSOPSの価値(宣言的・履歴付き・
+レビュー可能)がある。
+
+## 代替案と却下理由
+
+| 方式 | 却下/見送り理由 |
+|---|---|
+| HashiCorp Vault / OpenBAO | 常駐サーバ + unseal 運用が単独運用のN100に対して過大。可用性結合も生む |
+| Sealed Secrets | 復号鍵のバックアップが別途必要でSOPSに対する優位がなく、K8s限定で3層を賄えない |
+| Ansible Vault | K8s層を賄えない(3層統一不可) |
+| External Secrets / Infisical 等 | バックエンドの常駐サービスが増える |
+| 全面 SOPS | Terraform/単純ホスト秘密には過剰 |
+| 全面 env var | K8s Secret が命令的なままGitOps外に残る |
+
+## 結果
+
+### 良い点
+- 常駐サーバなし。N100に負荷を足さず、可用性結合も無い。
+- K8s Secret が宣言的GitOpsに乗り、バージョン管理・レビュー・drift検知の対象になる。
+- 守るべき鍵が **age秘密鍵1本** に集約(既存step-caの鍵運用と同型の損失時マトリクス)。
+- 公開リポジトリでも平文をコミットしない状態を全層で担保。
+
+### 注意点 / トレードオフ
+- 暗号文が**公開Gitの履歴に永続**する。age秘密鍵が漏れたら全シークレットのローテーションが必要。
+- 過去に平文だった値(`changeme`/`password`)は履歴から読めるため、**再暗号化ではなく新値へローテーション**する。
+- `apps` Kustomization は `sops-age` Secret 先行投入が前提(順序依存)。
+- 動的シークレット・監査ログ・集中管理UIは対象外。将来必要になれば OpenBAO / External Secrets へ
+  段階的に拡張できる(SOPSと排他ではない)。
+
+### スコープ
+本ADRは方式選定と配線・残骸撤去まで。実際のage鍵生成・シークレットの暗号化・値のローテーションは
+運用者が [docs/secret-management.md](../secret-management.md) の手順に従って実施する。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,13 @@
+# Architecture Decision Records (ADR)
+
+このディレクトリは、homelab の設計上の重要な決定を記録する ADR を置く。
+1決定 = 1ファイルとし、`NNNN-<短いタイトル>.md`(連番)で追加する。
+
+各ADRは概ね次の構成に従う: ステータス / コンテキスト / 決定 / 代替案と却下理由 / 結果(良い点・トレードオフ)。
+一度 Accepted にした決定を覆す場合は、古いADRを Superseded にして新しいADRを追加する。
+
+## 一覧
+
+| # | タイトル | ステータス |
+|---|---|---|
+| [0001](0001-secret-management.md) | シークレット管理の技術選定 (SOPS+age / env var) | Accepted |

--- a/docs/diagram.pu
+++ b/docs/diagram.pu
@@ -29,10 +29,6 @@ rectangle "Proxmox" {
   MATERIAL_STORAGE(ovm, OpenMediaVault)
  }
 
- rectangle "LXC - Vault" {
-  rectangle "Vault" as vault
- }
-
  rectangle "LXC - DNS" {
   rectangle "Pi-hole + Unbound" as pihole
  }
@@ -64,12 +60,10 @@ grafana --> loki
 
 ' LXCのPrometheusが非K3sノードのメトリクスを収集(node_exporter/blackbox)
 prometheus --> ovm
-prometheus --> vault
 prometheus --> pihole
 
 ' 非K3sノードのjournaldログをAlloyでLokiへ集約
 ovm --> loki
-vault --> loki
 pihole --> loki
 
 @enduml

--- a/docs/pki.md
+++ b/docs/pki.md
@@ -22,7 +22,6 @@ step-ca (LXC 192.168.0.211 / ca.home.arpa)
 - ルートCA/中間CAの秘密鍵は step-ca LXC 内(`/etc/step-ca`)にのみ存在する。**リポジトリには絶対にコミットしない**
 - ACMEアカウント鍵・サーバ証明書鍵は各クライアント(cert-manager/Caddy等)が自動生成・保管する
 - TLS対象はユーザー向けWeb UI/APIのみ。exporter類(:9100等)の内部メトリクスは対象外
-- Vault(secret-manager)は未構成のため対象外。実装時に最初からstep-ca証明書でlistenerをTLS化する
 
 ## 前提条件: home.arpa の名前解決
 

--- a/docs/secret-management.md
+++ b/docs/secret-management.md
@@ -1,0 +1,162 @@
+# シークレット管理 (K8s: SOPS+age / その他: 環境変数)
+
+homelab の秘密情報を「平文でGitに置かない」形に統一するための構成と運用手順。
+**このリポジトリは公開**である前提に立ち、Gitに入るのは暗号化済みファイルのみ、age秘密鍵は
+`docs/pki.md` のCA鍵と同じく **Git外・オフライン暗号化バックアップ** で扱う。
+
+## 方式
+
+秘密情報の消費者は3レイヤーあり、それぞれ最小コストの方式を採る。
+
+| レイヤー | 方式 | 秘密の保管場所 |
+|---|---|---|
+| Kubernetes (Flux) | **SOPS + age** | 暗号化した `*.sops.yaml` をGitにコミット。Fluxが復号 |
+| Ansible | 環境変数 lookup | ローカルの `.env`(direnv)。Gitには入れない |
+| Terraform | 環境変数 (`TF_VAR_*`) | ローカルの `.env`(direnv)。従来どおり |
+
+```
+                 age 秘密鍵 (keys.txt / Git外・オフラインBK)
+                        │
+          ┌─────────────┼───────────────────────────┐
+          │(site_flux.yml が投入)                    │(SOPS_AGE_KEY_FILE / direnv)
+          v                                          v
+  flux-system/sops-age Secret          sops CLI で *.sops.yaml を暗号化/復号
+          │                                          │
+          v                                          v
+  Flux kustomize-controller ── 復号 ──> K8s Secret (Authelia等)
+
+  Ansible ── lookup('env', ...) ──> DNS_WEB_PASSWORD / GRAFANA_ADMIN_PASSWORD / K3S_TOKEN
+  Terraform ── TF_VAR_* ──> Proxmox APIトークン等
+```
+
+## 採用理由 / 代替案比較
+
+「サーバーを増やさない(N100単独運用)」「GitOps(Flux)に適合」「秘密ゼロの損失時ストーリーが明快」を軸に評価した。
+
+| 方式 | サーバー要否 | GitOps適合 | 3層横断 | 採否 |
+|---|---|---|---|---|
+| **SOPS + age (K8s) + env var (他)** | 不要 | ○ | ○ | **採用** |
+| HashiCorp Vault / OpenBAO | 要(LXC常駐+unseal運用) | △ | ○ | 却下: 単独運用に運用コスト過大 |
+| Sealed Secrets | K8s内controller | ○ | K8s限定 | 却下: 復号鍵のBKが必要でSOPSに劣後、非K8s非対応 |
+| Ansible Vault | 不要 | K8s非対応 | × | 却下: K8s層を賄えない |
+| External Secrets / Infisical 等 | バックエンド常駐 | ○ | ○ | 却下: 常駐サービスが増える |
+| 全面 SOPS | 不要 | ○ | ○ | 見送り: Terraform/単純ホスト秘密には過剰 |
+| 全面 env var | 不要 | × | ○ | 見送り: K8s SecretがGitOps外(命令的)に残る |
+
+決定の記録は [docs/adr/0001-secret-management.md](adr/0001-secret-management.md) を参照。
+
+### なぜ K8s だけ SOPS で、他は環境変数か
+
+- **env varで十分な領域**: Terraform や単純なホスト秘密は、値を必要とするのがローカルCLIやapply時の一瞬だけで、保管・共有・バージョン管理が要らない。ここにSOPSを足すと手間が増えるだけ。
+- **SOPSが効く領域**: K8s Secretは「クラスタ内に存在」する必要があり、env varでは入れられない。現状 `site_flux.yml` は `kubectl create secret` で**命令的**に外挿しており、GitOps外・非バージョン管理・drift検知なし。SOPSなら暗号化Secretマニフェストを他のマニフェストと同様にGit管理でき、**宣言的・履歴付き・レビュー可能**になる。
+
+## `.sops.yaml` の設計
+
+リポジトリ直下の `.sops.yaml` に、K8s用の暗号化ルールのみを置く。
+
+```yaml
+creation_rules:
+  - path_regex: kubernetes/.*\.sops\.ya?ml$
+    encrypted_regex: "^(data|stringData)$"
+    age: age1...   # 公開recipient (秘密鍵ではない)
+```
+
+- `encrypted_regex` により `data`/`stringData` の **値だけ** を暗号化する。`apiVersion`/`kind`/`metadata`/キー名は平文で残るため、`git diff` でレビューできる(値は見えない)。
+- `age:` は**公開**recipientなのでコミット可。
+
+## 鍵の作成・配置 (導入時に一度だけ)
+
+```bash
+# 1. age 鍵ペアを生成 (秘密鍵は Git 外のここに置く)
+age-keygen -o ~/.config/sops/age/keys.txt
+#    → 標準エラーに公開鍵 age1... が表示される
+
+# 2. .sops.yaml の REPLACE_ME を、その公開鍵で置き換える
+
+# 3. .env に鍵ファイルパスと各シークレットを設定 (direnv が読み込む)
+#    .env.example を雛形にする
+SOPS_AGE_KEY_FILE="$HOME/.config/sops/age/keys.txt"
+DNS_WEB_PASSWORD="<新しい強いパスワード>"
+GRAFANA_ADMIN_PASSWORD="<新しい強いパスワード>"
+```
+
+`SOPS_AGE_KEY_FILE` はsops CLI・`site_flux.yml` の双方が参照する唯一の鍵の入口。
+
+## Kubernetes (Flux) への配線
+
+1. **復号鍵の投入**: `ansible/site_flux.yml` がブートストラップ時に、ローカルの `SOPS_AGE_KEY_FILE` から
+   `flux-system/sops-age` Secret を作成する(キー名 `age.agekey` 固定)。既存クラスタでは
+   `task ansible:run -- site_flux.yml` を流し直す。
+2. **復号の有効化**: `kubernetes/clusters/{production,staging}/apps.yaml` の `apps` Kustomization に
+   `decryption.provider: sops` / `secretRef.name: sops-age` を設定済み。
+3. **Secretの追加手順** (`kubernetes/apps/production/authelia/secret.sops.yaml.example` を参照):
+
+```bash
+cp secret.sops.yaml.example secret.sops.yaml
+# stringData に新規生成した値を記入してから暗号化
+sops --encrypt --in-place kubernetes/apps/production/authelia/secret.sops.yaml
+# 同ディレクトリの kustomization.yaml の resources に secret.sops.yaml を追加してコミット
+```
+
+> **適用順序の注意**: `apps` Kustomization は `sops-age` Secret が存在しないと復号でエラーになる。
+> 本方式を適用する際は先に `site_flux.yml`(sops-age投入) を実行してから、暗号化Secretをコミットすること。
+
+これにより [docs/sso.md](sso.md) が旧来Vaultに帰属させていたAuthelia secretの供給元が、このSOPS経路に置き換わる。
+
+## Ansible / Terraform (環境変数)
+
+平文をGitに置かず、既存の `STEP_CA_PASSWORD` / `GITHUB_TOKEN` と同じ direnv/env lookup 方式に統一した。
+
+| 変数(env) | 参照箇所 | 事前チェック |
+|---|---|---|
+| `DNS_WEB_PASSWORD` | `group_vars/dns.yml` → Pi-hole `WEBPASSWORD` | `site_dns.yml` の assert |
+| `GRAFANA_ADMIN_PASSWORD` | `group_vars/grafana.yml` → Grafana admin | `site_monitoring.yml` の assert |
+| `K3S_TOKEN` | `group_vars/k3s_*_cluster.yml` (任意・既定コメントアウト) | — |
+| `TF_VAR_*` | `terraform/proxmox/` | Terraform変数(`sensitive`) |
+
+env未設定のまま実行すると assert で早期失敗する(空パスワードで適用されるのを防ぐ)。
+
+## 鍵のバックアップと紛失時
+
+`docs/pki.md` のCA鍵と同じ方針。守るべきは **age秘密鍵1本** に集約される。
+
+| 失うもの | 影響 |
+|---|---|
+| age公開鍵 (recipient) | 問題なし。`.sops.yaml` にコミット済で再取得可 |
+| age秘密鍵 (バックアップあり) | 復元可。`keys.txt` を復旧すれば全 `*.sops.yaml` を復号できる |
+| age秘密鍵 (バックアップなし) | 復号不可。新しい鍵を生成し、全 `*.sops.yaml` を新recipientへ再暗号化(値の再入力が必要) |
+| `.env` (ローカル秘密) | 各サービスの値を再設定して該当playbookを流し直す |
+
+- `keys.txt` は **暗号化してオフラインバックアップ** する。公開リポジトリには絶対に置かない。
+- 鍵が漏洩した場合は、公開履歴の暗号文は復号可能になるため **全シークレットをローテーション** する。
+
+## 既存平文シークレットのローテーション (必須)
+
+過去に平文 (`changeme` / `password`) が公開Gitの履歴に入っていたため、**同じ値の再利用は無意味**。
+必ず新しい強い値を生成して設定し、該当サービスへ反映する。
+
+```bash
+# 例: 新値を .env に設定後、対象playbookを流し直す
+task ansible:run -- site_dns.yml         # Pi-hole 管理パスワード
+task ansible:run -- site_monitoring.yml  # Grafana admin パスワード
+```
+
+## 検証
+
+```bash
+# SOPS ラウンドトリップ (鍵がある時のみ復号できる)
+sops -d kubernetes/apps/production/authelia/secret.sops.yaml
+git show HEAD:kubernetes/apps/production/authelia/secret.sops.yaml   # 値が暗号文であること
+
+# Flux: 復号鍵と反映確認
+kubectl -n flux-system get secret sops-age
+flux get kustomizations                       # apps が Ready=True
+kubectl -n <ns> get secret <name>             # 復号された Secret がクラスタ内に materialize
+
+# Ansible: env から値が解決されること / 未設定なら assert 失敗
+ansible -m debug -a "var=dns_web_password" dns
+task ansible:run -- site_dns.yml
+
+# Terraform: 変更後も検証が通ること
+terraform -chdir=terraform/proxmox validate
+```

--- a/docs/sso.md
+++ b/docs/sso.md
@@ -39,7 +39,7 @@ IdPは **Authelia** を採用予定。
 
 ## 次フェーズの作業(未実施)
 
-1. シークレット管理の実装(Vault @ `vault.home.arpa`)— Autheliaのsecret類(JWT/セッション/OIDC HMAC・秘密鍵)の供給元
+1. Autheliaのsecret類(JWT/セッション/OIDC HMAC・秘密鍵)は **SOPS+age** で暗号化した `secret.sops.yaml` をFluxが復号して供給する(→ [docs/secret-management.md](secret-management.md))
 2. Authelia のデプロイ(Flux HelmRelease + Ingress `auth.home.arpa`)
 3. ユーザーDB(まずはファイルベース)とセッションストア(小規模ならメモリ/SQLite、必要ならRedis)
 4. OIDCクライアント登録(Grafana等)と Traefik `forwardAuth` ミドルウェアの適用

--- a/flake.nix
+++ b/flake.nix
@@ -23,10 +23,11 @@
             ansible
             gnutar
             go-task
+            sops age
           ];
           shellHook = ''
             echo "🏠 Homelab dev environment loaded!"
-            echo "Available tools: python3, terraform, kubectl, helm, fluxcd, ansible go-task"
+            echo "Available tools: python3, terraform, kubectl, helm, fluxcd, ansible, go-task, sops, age"
           '';
         };
       });

--- a/kubernetes/apps/production/authelia/secret.sops.yaml.example
+++ b/kubernetes/apps/production/authelia/secret.sops.yaml.example
@@ -1,0 +1,22 @@
+# SOPS 暗号化 Secret のテンプレート（代表例: 将来の Authelia 用シークレット）
+#
+# 使い方:
+#   1. このファイルを secret.sops.yaml にコピーし、stringData に実値を記入する
+#      (履歴に残る値は使わず、必ず新規生成した強い値にする)
+#   2. sops --encrypt --in-place secret.sops.yaml で stringData の値だけを暗号化する
+#   3. 同ディレクトリの kustomization.yaml の resources に secret.sops.yaml を追加する
+#   4. コミットすると Flux (apps Kustomization の decryption) が復号して適用する
+#
+# .yaml.example 拡張子のため Flux/kustomize には取り込まれない（テンプレート専用）。
+# 詳細は docs/secret-management.md を参照。
+apiVersion: v1
+kind: Secret
+metadata:
+  name: authelia-secrets
+  namespace: authelia
+type: Opaque
+stringData:
+  # 例: openssl rand -hex 32 などで生成した値を入れてから sops で暗号化する
+  jwt-secret: REPLACE_ME
+  session-secret: REPLACE_ME
+  oidc-hmac-secret: REPLACE_ME

--- a/kubernetes/clusters/production/apps.yaml
+++ b/kubernetes/clusters/production/apps.yaml
@@ -15,3 +15,9 @@ spec:
   prune: true
   wait: true
   timeout: 5m0s
+  # SOPS で暗号化した Secret (*.sops.yaml) を復号する。
+  # 復号鍵は site_flux.yml が投入する flux-system/sops-age Secret。
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/kubernetes/clusters/staging/apps.yaml
+++ b/kubernetes/clusters/staging/apps.yaml
@@ -15,3 +15,9 @@ spec:
   prune: true
   wait: true
   timeout: 5m0s
+  # SOPS で暗号化した Secret (*.sops.yaml) を復号する。
+  # 復号鍵は site_flux.yml が投入する flux-system/sops-age Secret。
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/taskfiles/Terraform.yml
+++ b/taskfiles/Terraform.yml
@@ -29,30 +29,6 @@ tasks:
     cmds:
       - terraform destroy
 
-  vault:init:
-    desc: Run terraform init
-    dir: "{{.TERRAFORM_DIR}}/vault-config/"
-    cmds:
-      - terraform init
-
-  vault:plan:
-    desc: Run terraform plan
-    dir: "{{.TERRAFORM_DIR}}/vault-config/"
-    cmds:
-      - terraform plan
-
-  vault:apply:
-    desc: Run terraform apply
-    dir: "{{.TERRAFORM_DIR}}/vault-config/"
-    cmds:
-      - terraform apply -auto-approve
-
-  vault:destroy:
-    desc: Run terraform destroy
-    dir: "{{.TERRAFORM_DIR}}/vault-config/"
-    cmds:
-      - terraform destroy
-
   fmt:
     desc: Run terraform fmt
     dir: "{{.TERRAFORM_DIR}}/"

--- a/terraform/proxmox/import.tf
+++ b/terraform/proxmox/import.tf
@@ -19,10 +19,6 @@
 #   id = "${var.target_node}/vm/${var.openmediavault_vmid}"
 # }
 # import {
-#   to = module.secret_manager.proxmox_lxc.this
-#   id = "${var.target_node}/lxc/${var.secret_manager_vmid}"
-# }
-# import {
 #   to = module.dns.proxmox_lxc.this
 #   id = "${var.target_node}/lxc/${var.dns_vmid}"
 # }

--- a/terraform/proxmox/main.tf
+++ b/terraform/proxmox/main.tf
@@ -130,42 +130,6 @@ module "openmediavault" {
   passthrough_file = var.openmediavault_passthrough_file
 }
 
-// Secret Manager
-module "secret_manager" {
-  source = "./modules/proxmox-lxc"
-
-  target_node = var.target_node
-
-  ostemplate      = var.lxc_ostemplate
-  cpuunits        = var.secret_manager_cpuunits
-  hostname        = var.secret_manager_hostname
-  memory          = var.secret_manager_memory
-  onboot          = var.secret_manager_onboot
-  network_ip      = var.secret_manager_network_ip
-  network_gw      = var.lxc_gw
-  rootfs_size     = var.secret_manager_rootfs_size
-  ssh_public_keys = var.sshkeys
-  swap            = var.secret_manager_swap
-  vmid            = var.secret_manager_vmid
-}
-// local-exec不要で作成後の起動ができるようになったため削除
-# resource "null_resource" "configure_secret_manager" {
-#   depends_on = [module.secret_manager]
-
-#   provisioner "local-exec" {
-#     environment = {
-#       PM_API_URL = var.pm_api_url
-#       NODE       = var.target_node
-#       VMID       = var.secret_manager_vmid
-#       TOKEN      = "${var.pm_api_token_id}=${var.pm_api_token_secret}"
-#     }
-#     command = <<EOT
-#         curl -k -X POST "$PM_API_URL/nodes/$NODE/lxc/$VMID/status/start" \
-#             -H "Authorization: PVEAPIToken=$TOKEN"
-#     EOT
-#   }
-# }
-
 // monitoring
 module "monitoring" {
   source = "./modules/proxmox-lxc"

--- a/terraform/proxmox/variables.tf
+++ b/terraform/proxmox/variables.tf
@@ -199,40 +199,6 @@ variable "openmediavault_storage_size" {
   default = "6G"
 }
 
-// LXC - Secret Manager
-variable "secret_manager_cpuunits" {
-  type    = number
-  default = 1024
-}
-variable "secret_manager_hostname" {
-  type    = string
-  default = "secret-manager"
-}
-variable "secret_manager_memory" {
-  type    = number
-  default = 1024
-}
-variable "secret_manager_onboot" {
-  type    = bool
-  default = true
-}
-variable "secret_manager_network_ip" {
-  type    = string
-  default = "192.168.0.212/24"
-}
-variable "secret_manager_rootfs_size" {
-  type    = string
-  default = "8G"
-}
-variable "secret_manager_swap" {
-  type    = number
-  default = 512
-}
-variable "secret_manager_vmid" {
-  type    = number
-  default = 212
-}
-
 // LXC-monitoring
 variable "monitoring_cpuunits" {
   type    = number


### PR DESCRIPTION
## 概要

シークレット管理を1から技術選定して導入する。Vaultの残骸は確定扱いにせず撤去した。
常駐サーバを増やさず（単独運用ホストに優しい）、Flux GitOps に適合する構成を採用している。

- 決定の記録: `docs/adr/0001-secret-management.md`（ADR運用の枠として `docs/adr/README.md` も新設）
- 設計・運用手順: `docs/secret-management.md`

## 方式

| レイヤー | 方式 |
|---|---|
| Kubernetes (Flux) | **SOPS + age**（暗号化した `*.sops.yaml` をコミットし Flux が復号） |
| Ansible | 環境変数 lookup（既存の `STEP_CA_PASSWORD` 等と同方式） |
| Terraform | `TF_VAR_*` を維持（Gitに平文が無いため対象外） |

代替案（Vault/OpenBAO・Sealed Secrets・Ansible Vault・全面SOPS/全面env var）の比較と却下理由は ADR を参照。

## 変更点

**K8s (Flux) — SOPS+age 配線**
- `.sops.yaml` を追加（`encrypted_regex` で値のみ暗号化。recipient はプレースホルダ）
- `ansible/site_flux.yml` がブートストラップ時に復号鍵 Secret を投入（未設定検知の assert つき）
- production/staging の `apps` Kustomization に `decryption` ブロックを追加
- 追加手順のテンプレート `kubernetes/apps/production/authelia/secret.sops.yaml.example`
- `flake.nix` の devShell に `sops` / `age` を追加

**Ansible — 平文プレースホルダを環境変数 lookup へ移行**
- Pi-hole 管理パスワード / Grafana admin パスワード / K3s トークンを `lookup('env', ...)` 化
- `site_dns.yml` / `site_monitoring.yml` に未設定検知の assert
- `.env.example` に対応する変数を追記

**Vault 残骸の撤去**
- 空の `terraform/vault-config/` と `taskfiles` の `vault:*` タスク
- 退役する secret-manager 用 LXC モジュールと、それに紐づく監視ターゲット / インベントリ / DNS レコードの予約
- `docs/diagram.pu` / `docs/sso.md` / `docs/pki.md` の Vault 記述

**ドキュメント**
- `docs/secret-management.md`（採用理由・鍵バックアップ/紛失時マトリクス・適用手順・検証コマンド）を新規追加

## 適用時の注意（運用者作業）

1. `age-keygen` で鍵を生成し、`.sops.yaml` の `REPLACE_ME` を公開鍵で置換、`.env` に鍵ファイルパスと各値を設定する
2. **順序依存**: `apps` Kustomization は復号鍵 Secret が未投入だとエラーになる。先に `site_flux.yml` を流してから暗号化 Secret をコミット/反映すること（詳細は `docs/secret-management.md`）
3. 過去に平文だった値は履歴から読めるため、**同じ値を使わず新しい値へローテーション**する

## 検証状況

- 変更した YAML の構文チェック（OK）、Terraform 削除箇所の整形目視、残存参照ゼロを確認
- devShell 依存ツール（`terraform` / `ansible-lint` / `task`）はローカル環境に無く未実行 → CI（`terraform-ci` / `ansible-ci`）での確認を想定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017EVxWTvFpf7CzAasNoCUSY)_