### PR TITLE
feat(network-policies): add default-deny ingress NetworkPolicies

### DIFF
--- a/kubernetes/clusters/production/infrastructure.yaml
+++ b/kubernetes/clusters/production/infrastructure.yaml
@@ -104,3 +104,28 @@ spec:
   path: ./kubernetes/infrastructure/traefik
   prune: true
   wait: true
+
+---
+# 各 namespace の Pod 間通信を最小権限化する NetworkPolicy 群。
+# 対象 namespace が先に存在している必要があるため、それらを作る Kustomization に依存させる。
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: network-policies
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: metallb-system
+    - name: cert-manager
+    - name: traefik
+    # homepage / logging / metrics の namespace は apps が作成する
+    - name: apps
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/infrastructure/network-policies/production
+  prune: true
+  wait: true

--- a/kubernetes/clusters/staging/infrastructure.yaml
+++ b/kubernetes/clusters/staging/infrastructure.yaml
@@ -26,3 +26,25 @@ spec:
       target:
         name: first-pool
         kind: IPAddressPool
+
+---
+# 各 namespace の Pod 間通信を最小権限化する NetworkPolicy 群(staging は metallb-system + nginx)。
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: network-policies
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  dependsOn:
+    - name: metallb-system
+    # nginx の namespace は apps が作成する
+    - name: apps
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./kubernetes/infrastructure/network-policies/staging
+  prune: true
+  wait: true

--- a/kubernetes/infrastructure/network-policies/README.md
+++ b/kubernetes/infrastructure/network-policies/README.md
@@ -1,0 +1,71 @@
+# network-policies
+
+各 namespace の Pod 間通信を最小権限化するための `networking.k8s.io/v1` NetworkPolicy 群。
+K3s 標準 CNI(Flannel + kube-router 内蔵 NetworkPolicy コントローラ)で強制されるため、追加コンポーネントは不要。
+
+## 方針
+
+- **default-deny は Ingress 方向のみ**。egress deny は apiserver(node IP:6443)や DNS への到達性を壊しやすいため、今回は導入しない。
+- namespace の指定には K8s 1.21+ の自動ラベル `kubernetes.io/metadata.name` を使う(手動ラベル付与は不要)。
+- 各ポリシーは `podSelector: {}` + ポート/送信元で絞る(chart 固有ラベルはアップグレードで壊れやすいため使わない)。
+- `flux-system` と `kube-system` は対象外(前者は Flux 生成ポリシーで実質ロック済み、後者は CoreDNS 障害リスクのため)。
+
+## 構成
+
+```
+base/<namespace>/   … namespace ごとの default-deny + 許可ポリシー
+production/         … base/{metallb-system,traefik,cert-manager,homepage,logging,metrics}
+staging/           … base/{metallb-system,nginx}
+```
+
+Flux からは `clusters/<cluster>/infrastructure.yaml` の `network-policies` Kustomization が
+overlay(`production` / `staging`)を参照する。namespace が先に存在する必要があるため
+`dependsOn` に該当 Kustomization を指定している。
+
+## 許可ルール一覧(いずれも Ingress)
+
+| namespace | ポリシー | 送信元 → ポート | 目的 |
+|---|---|---|---|
+| metallb-system | allow-webhook | `192.168.0.0/24` → 9443 | validating webhook(apiserver は node IP 発) |
+| traefik | allow-entrypoints | `/24` + 全 ns → 8000, 8443 | web/websecure entrypoint |
+| homepage | allow-traefik | traefik ns → 3000, 8089 | アプリ本体 + ACME HTTP-01 solver |
+| logging | allow-intra-namespace | 同一 ns 全 Pod | promtail→gateway→loki |
+| logging | allow-lan-gateway | `/24` → 8080 | 外部 Grafana(.214)→ Loki gateway(LB .233) |
+| metrics | allow-intra-namespace | 同一 ns 全 Pod | prometheus↔alertmanager 等 |
+| metrics | allow-webhook | `/24` → 10250 | prometheus-operator admission webhook |
+| metrics | allow-lan-prometheus | `/24` → 9090 | 外部 Grafana(.214)→ Prometheus(LB .232) |
+| cert-manager | allow-webhook | `/24` → 10250 | cert-manager webhook |
+| nginx (staging) | allow-lan | `/24` → 80 | LB .161 で LAN 公開 |
+
+`allow-metrics-scrape`(metrics ns → 各アプリの metrics ポート)は将来の ServiceMonitor 用に
+metallb-system / logging / cert-manager へ用意してある(現状は非マッチでも無害)。
+
+## kube-router 固有の注意点
+
+- **hostNetwork Pod は NetworkPolicy 非対象**(metallb speaker, node-exporter)。node-exporter :9100 は LAN 到達可能なまま。
+- **admission webhook 呼び出しは node IP 発**で届くため、`/24` からの 10250/9443 許可が必須(default-deny の典型的な落とし穴)。
+- **kubelet の liveness/readiness プローブは同一 node 発**で kube-router が常に許可するため追加ルール不要。
+- **kube-router はポリシーのログを出さない**。デバッグは下記の負テスト Pod と、node 上の `iptables -L KUBE-ROUTER-FORWARD` / `ipset list` で行う。
+
+## 動作確認
+
+```sh
+# ポリシー一覧
+kubectl get netpol -A
+
+# 正常系(LAN から / staging)
+curl http://192.168.0.161
+
+# 負テスト(default ns の Pod からは拒否されること)
+kubectl run curl --rm -it -n default --image=curlimages/curl -- \
+  curl -m3 nginx-service.nginx
+```
+
+## ロールバック(キルスイッチ)
+
+```sh
+flux suspend kustomization network-policies -n flux-system
+kubectl delete netpol -A -l app.kubernetes.io/part-of=network-policies
+```
+
+その後、該当コミットを revert する。

--- a/kubernetes/infrastructure/network-policies/base/cert-manager/kustomization.yaml
+++ b/kubernetes/infrastructure/network-policies/base/cert-manager/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cert-manager
+resources:
+  - networkpolicy.yaml

--- a/kubernetes/infrastructure/network-policies/base/cert-manager/networkpolicy.yaml
+++ b/kubernetes/infrastructure/network-policies/base/cert-manager/networkpolicy.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/part-of: network-policies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+# apiserver(server node のホスト IP 発)からの cert-manager webhook(containerPort 10250)を許可。
+# 無いと Certificate / Issuer の CRUD(= Flux の apply)が全て拒否される。
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-webhook
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/part-of: network-policies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 192.168.0.0/24
+      ports:
+        - port: 10250
+          protocol: TCP
+---
+# 将来 metrics namespace の ServiceMonitor から scrape する場合に備える(cert-manager metrics 9402)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-metrics-scrape
+  namespace: cert-manager
+  labels:
+    app.kubernetes.io/part-of: network-policies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: metrics
+      ports:
+        - port: 9402
+          protocol: TCP

--- a/kubernetes/infrastructure/network-policies/base/homepage/kustomization.yaml
+++ b/kubernetes/infrastructure/network-policies/base/homepage/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: homepage
+resources:
+  - networkpolicy.yaml

--- a/kubernetes/infrastructure/network-policies/base/homepage/networkpolicy.yaml
+++ b/kubernetes/infrastructure/network-policies/base/homepage/networkpolicy.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: homepage
+  labels:
+    app.kubernetes.io/part-of: network-policies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+# Traefik からの流入のみ許可。
+# - 3000: homepage の containerPort(Service は 80 -> targetPort 3000)
+# - 8089: cert-manager の HTTP-01 acmesolver Pod は Ingress の namespace(=homepage)に作られるため、
+#         Traefik がそこへ到達できないと homepage-tls の発行・更新が失敗する
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-traefik
+  namespace: homepage
+  labels:
+    app.kubernetes.io/part-of: network-policies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: traefik
+      ports:
+        - port: 3000
+          protocol: TCP
+        - port: 8089
+          protocol: TCP

--- a/kubernetes/infrastructure/network-policies/base/logging/kustomization.yaml
+++ b/kubernetes/infrastructure/network-policies/base/logging/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: logging
+resources:
+  - networkpolicy.yaml

--- a/kubernetes/infrastructure/network-policies/base/logging/networkpolicy.yaml
+++ b/kubernetes/infrastructure/network-policies/base/logging/networkpolicy.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: logging
+  labels:
+    app.kubernetes.io/part-of: network-policies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+# namespace 内の通信を全許可(promtail -> loki-gateway:8080 -> loki:3100/9095 のパイプライン)。
+# from の podSelector: {} は「同一 namespace の全 Pod」を意味する。
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-intra-namespace
+  namespace: logging
+  labels:
+    app.kubernetes.io/part-of: network-policies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+---
+# 外部 Grafana(192.168.0.214)が LB .233 経由で Loki gateway(containerPort 8080)へクエリする分。
+# LB 側に sourceRanges が無いため /24 で許可(externalTrafficPolicy: Cluster の node SNAT もカバー)。
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-lan-gateway
+  namespace: logging
+  labels:
+    app.kubernetes.io/part-of: network-policies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 192.168.0.0/24
+      ports:
+        - port: 8080
+          protocol: TCP
+---
+# 将来 metrics namespace の ServiceMonitor から scrape する場合に備える(loki:3100 / promtail:3101)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-metrics-scrape
+  namespace: logging
+  labels:
+    app.kubernetes.io/part-of: network-policies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: metrics
+      ports:
+        - port: 3100
+          protocol: TCP
+        - port: 3101
+          protocol: TCP

--- a/kubernetes/infrastructure/network-policies/base/metallb-system/kustomization.yaml
+++ b/kubernetes/infrastructure/network-policies/base/metallb-system/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metallb-system
+resources:
+  - networkpolicy.yaml

--- a/kubernetes/infrastructure/network-policies/base/metallb-system/networkpolicy.yaml
+++ b/kubernetes/infrastructure/network-policies/base/metallb-system/networkpolicy.yaml
@@ -1,0 +1,55 @@
+---
+# metallb-system: controller のみポリシー対象(speaker は hostNetwork のため NetworkPolicy 非対象)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: metallb-system
+  labels:
+    app.kubernetes.io/part-of: network-policies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+# apiserver(server node のホスト IP 発)からの validating webhook 呼び出しを許可。
+# 無いと IPAddressPool/L2Advertisement/LoadBalancer Service の変更が全て拒否される。
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-webhook
+  namespace: metallb-system
+  labels:
+    app.kubernetes.io/part-of: network-policies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 192.168.0.0/24
+      ports:
+        - port: 9443
+          protocol: TCP
+---
+# 将来 metrics namespace の ServiceMonitor から scrape する場合に備える(staging には metrics が無いため常に非マッチ=無害)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-metrics-scrape
+  namespace: metallb-system
+  labels:
+    app.kubernetes.io/part-of: network-policies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: metrics
+      ports:
+        - port: 7472
+          protocol: TCP

--- a/kubernetes/infrastructure/network-policies/base/metrics/kustomization.yaml
+++ b/kubernetes/infrastructure/network-policies/base/metrics/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: metrics
+resources:
+  - networkpolicy.yaml

--- a/kubernetes/infrastructure/network-policies/base/metrics/networkpolicy.yaml
+++ b/kubernetes/infrastructure/network-policies/base/metrics/networkpolicy.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: metrics
+  labels:
+    app.kubernetes.io/part-of: network-policies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+# namespace 内の通信を全許可(prometheus -> alertmanager:9093 / kube-state-metrics / operator など)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-intra-namespace
+  namespace: metrics
+  labels:
+    app.kubernetes.io/part-of: network-policies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+---
+# apiserver(server node のホスト IP 発)からの prometheus-operator admission webhook(containerPort 10250)を許可。
+# 無いと ServiceMonitor / PrometheusRule の apply(= Flux の HelmRelease reconcile)が全て失敗する。
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-webhook
+  namespace: metrics
+  labels:
+    app.kubernetes.io/part-of: network-policies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 192.168.0.0/24
+      ports:
+        - port: 10250
+          protocol: TCP
+---
+# 外部 Grafana(192.168.0.214)が LB .232 経由で Prometheus(containerPort 9090)へクエリする分。
+# LB 側で loadBalancerSourceRanges: 192.168.0.214/32 に既に制限済み。
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-lan-prometheus
+  namespace: metrics
+  labels:
+    app.kubernetes.io/part-of: network-policies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 192.168.0.0/24
+      ports:
+        - port: 9090
+          protocol: TCP

--- a/kubernetes/infrastructure/network-policies/base/nginx/kustomization.yaml
+++ b/kubernetes/infrastructure/network-policies/base/nginx/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: nginx
+resources:
+  - networkpolicy.yaml

--- a/kubernetes/infrastructure/network-policies/base/nginx/networkpolicy.yaml
+++ b/kubernetes/infrastructure/network-policies/base/nginx/networkpolicy.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: nginx
+  labels:
+    app.kubernetes.io/part-of: network-policies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+# nginx は LB .161 で LAN 公開(Traefik 経由ではない)。/24 は node SNAT もカバー。
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-lan
+  namespace: nginx
+  labels:
+    app.kubernetes.io/part-of: network-policies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 192.168.0.0/24
+      ports:
+        - port: 80
+          protocol: TCP

--- a/kubernetes/infrastructure/network-policies/base/traefik/kustomization.yaml
+++ b/kubernetes/infrastructure/network-policies/base/traefik/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: traefik
+resources:
+  - networkpolicy.yaml

--- a/kubernetes/infrastructure/network-policies/base/traefik/networkpolicy.yaml
+++ b/kubernetes/infrastructure/network-policies/base/traefik/networkpolicy.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: traefik
+  labels:
+    app.kubernetes.io/part-of: network-policies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+# entrypoint(web=8000 / websecure=8443, chart の containerPort)への流入を許可。
+# - ipBlock 192.168.0.0/24: LAN クライアント + externalTrafficPolicy: Cluster による node SNAT
+# - namespaceSelector: {}   : クラスタ内クライアント(cert-manager の ACME セルフチェックが LB .230 経由でヘアピンする分を含む)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-entrypoints
+  namespace: traefik
+  labels:
+    app.kubernetes.io/part-of: network-policies
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 192.168.0.0/24
+        - namespaceSelector: {}
+      ports:
+        - port: 8000
+          protocol: TCP
+        - port: 8443
+          protocol: TCP

--- a/kubernetes/infrastructure/network-policies/production/kustomization.yaml
+++ b/kubernetes/infrastructure/network-policies/production/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base/metallb-system
+  - ../base/traefik
+  - ../base/cert-manager
+  - ../base/homepage
+  - ../base/logging
+  - ../base/metrics

--- a/kubernetes/infrastructure/network-policies/staging/kustomization.yaml
+++ b/kubernetes/infrastructure/network-policies/staging/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base/metallb-system
+  - ../base/nginx


### PR DESCRIPTION
## 概要

各 namespace の Pod 間通信を「全開放」から「最小権限」へ移行するため、`networking.k8s.io/v1` NetworkPolicy 群を追加します。現状 `flux-system` 以外の全 namespace は Pod 間通信が無制限で、任意の Pod(や侵害された Pod)が Loki / Prometheus 等へ直接到達できる状態でした。

K3s 標準 CNI(Flannel + kube-router 内蔵 NetworkPolicy コントローラ)でそのまま強制されるため、**CNI の変更やサービスメッシュの導入は不要**です。

> [!NOTE]
> 本 PR で新規に追加する外部参照値は、既にリポジトリ内で公開済みの LAN 内プライベート IP(`192.168.0.0/24`、RFC1918)のみです。シークレット・トークン・外部ホスト名等は含みません。

## 設計方針

- **default-deny は Ingress 方向のみ**。egress deny は apiserver(node IP:6443)や DNS への到達性を壊しやすいため今回は見送り(将来の任意強化として `README.md` に記載)。
- namespace 指定は K8s 1.21+ 自動ラベル `kubernetes.io/metadata.name` を使用(手動ラベル付与不要)。
- 各ポリシーは `podSelector: {}` + ポート/送信元で絞る(chart 固有ラベルはアップグレードで壊れやすいため不使用)。
- `flux-system` / `kube-system` は対象外(前者は Flux 生成ポリシーで実質ロック済み、後者は CoreDNS 障害リスク)。
- 配置は中央集約型(`kubernetes/infrastructure/network-policies/`、base + クラスタ別 overlay)。共通ラベル `app.kubernetes.io/part-of=network-policies` で一括ロールバック(キルスイッチ)可能。

## 変更内容

- **新規**: `kubernetes/infrastructure/network-policies/`
  - `base/<namespace>/` … metallb-system / traefik / cert-manager / homepage / logging / metrics / nginx それぞれの default-deny + 許可ポリシー
  - `production/` overlay(metallb-system, traefik, cert-manager, homepage, logging, metrics)
  - `staging/` overlay(metallb-system, nginx)
  - `README.md`(ポリシー一覧表・kube-router 注意点・動作確認・ロールバック手順)
- **修正**: `kubernetes/clusters/{production,staging}/infrastructure.yaml` に `network-policies` Flux Kustomization を追記。対象 namespace が先に存在する必要があるため `dependsOn` を設定。

## 主な許可ルール(いずれも Ingress)

| namespace | 送信元 → ポート | 目的 |
|---|---|---|
| traefik | `/24` + 全 ns → 8000, 8443 | web/websecure entrypoint |
| homepage | traefik ns → 3000, 8089 | アプリ本体 + ACME HTTP-01 solver |
| logging | 同一 ns / `/24` → 8080 | promtail→loki パイプライン / 外部 Grafana(LB .233) |
| metrics | 同一 ns / `/24` → 10250, 9090 | prometheus-operator webhook / 外部 Grafana(LB .232) |
| cert-manager | `/24` → 10250 | cert-manager webhook |
| metallb-system | `/24` → 9443 | validating webhook |
| nginx (staging) | `/24` → 80 | LB .161 で LAN 公開 |

> [!IMPORTANT]
> admission webhook 呼び出しは apiserver(server node のホスト IP)発で届くため、`/24` からの 10250/9443 許可が必須です。無いと ServiceMonitor / Certificate の apply(= Flux reconcile)が失敗します。hostNetwork Pod(metallb speaker, node-exporter)は NetworkPolicy 非対象です。

## 検証

- ローカルで YAML 構文・kustomize 参照整合性・「default-deny に ingress ルールが無いこと」を確認済み(NetworkPolicy 20 件)。
- クラスタ適用時のロールアウト手順(staging → production)と正/負テスト、ロールバック手順は `README.md` に記載。

## ロールアウト

staging で検証(`curl http://192.168.0.161` = 200、default ns の Pod からは拒否)後、production を配線する二段階を想定しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnSmir4DruQujWEaHoYmqu)_